### PR TITLE
Add a container-based Swift environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# Development environment for building and testing Scientist on Linux.
+# CI builds on macOS; this image is for local work and reproduces the
+# Swift 6 toolchain without depending on whatever is installed on the host.
+FROM docker.io/library/swift:6.1
+
+# swift-format ships with the toolchain from Swift 6.0 onward, so `swift format`
+# (used by CI) works here without extra installation.
+WORKDIR /workspace
+
+CMD ["swift", "test"]

--- a/scripts/swift-container.sh
+++ b/scripts/swift-container.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Run a Swift command inside the project's container image.
+#
+#   scripts/swift-container.sh                # swift test
+#   scripts/swift-container.sh swift build -v
+#   scripts/swift-container.sh bash           # interactive shell
+#
+# Uses docker if present, otherwise podman. Build artifacts live in a named
+# volume so they never collide with the host's own .build directory.
+set -euo pipefail
+
+IMAGE="scientist-dev"
+VOLUME="scientist-build"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ENGINE_FLAGS=()
+if command -v docker >/dev/null 2>&1; then
+  ENGINE=docker
+elif command -v podman >/dev/null 2>&1; then
+  ENGINE=podman
+  # Rootless podman without a systemd user session (e.g. WSL) cannot use the
+  # systemd cgroup manager or the journald events backend.
+  if [ ! -S "/run/user/$(id -u)/bus" ]; then
+    ENGINE_FLAGS=(--cgroup-manager=cgroupfs --events-backend=file)
+  fi
+else
+  echo "error: neither docker nor podman is installed." >&2
+  exit 1
+fi
+
+if ! "$ENGINE" "${ENGINE_FLAGS[@]}" image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "==> building $IMAGE with $ENGINE"
+  "$ENGINE" "${ENGINE_FLAGS[@]}" build -t "$IMAGE" "$ROOT"
+fi
+
+if [ "$#" -eq 0 ]; then
+  set -- swift test
+fi
+
+# -t only when attached to a terminal, so CI and pipes keep working.
+TTY_FLAGS=(-i)
+[ -t 0 ] && TTY_FLAGS+=(-t)
+
+exec "$ENGINE" "${ENGINE_FLAGS[@]}" run --rm "${TTY_FLAGS[@]}" \
+  -v "$ROOT:/workspace:z" \
+  -v "$VOLUME:/workspace/.build" \
+  -w /workspace \
+  "$IMAGE" \
+  "$@"


### PR DESCRIPTION
CI only runs on macOS, so there was no supported way to build or test this package on Linux.

Adds a Swift 6.1 image and `scripts/swift-container.sh`, which runs the same commands CI runs:

```sh
./scripts/swift-container.sh                        # swift test
./scripts/swift-container.sh swift build -v
./scripts/swift-container.sh swift format lint -r Sources Tests
```

The script prefers docker and falls back to podman, adding the flags rootless podman needs when no systemd user session is available. Build artifacts go to a named volume so the host's `.build` is untouched.