### PR TITLE
Document the public API

### DIFF
--- a/Sources/Scientist/Error.swift
+++ b/Sources/Scientist/Error.swift
@@ -8,8 +8,18 @@
 
 import Foundation
 
+/// Errors thrown by ``Experiment/run(name:)``.
 public enum ExperimentError: Error {
+  /// No behavior is registered under the requested name.
+  ///
+  /// Either the control was never registered with ``Experiment/use(control:)``, or the
+  /// `"run"` option named a candidate that does not exist.
   case behaviorNotFound
+
+  /// The behaviors ran, but no observation was produced for the requested name, so there
+  /// is no value to return.
   case valueNotReturned
+
+  /// A failure with no more specific case.
   case unknownError
 }

--- a/Sources/Scientist/Experiment.swift
+++ b/Sources/Scientist/Experiment.swift
@@ -6,9 +6,23 @@
 //  Copyright © 2018 Yusuke Ohashi. All rights reserved.
 //
 
-/// `Experiment` class manages blocks for experimental logics, and performs publishing of your experiment results.
+/// Runs a control block alongside one or more candidate blocks, compares what they
+/// returned, and hands the outcome to ``publish``.
+///
+/// Configure an experiment inside the closure passed to
+/// ``Scientist/science(name:options:_:)``: register the existing code path with
+/// ``use(control:)``, each new one with ``tryNew(name:candidate:)``, and set ``enabled``
+/// to decide whether the candidates run at all.
+///
+/// Whatever the candidates return, ``run(name:)`` returns the control's value, so putting
+/// a code path under experiment does not change what the caller sees.
 final public class Experiment<T: Equatable> {
+  /// A behavior under experiment: either the control or a candidate.
   public typealias ExperimentBlock = () -> T
+
+  /// Decides whether a candidate's value is equivalent to the control's.
+  ///
+  /// Used in place of `==` when one is registered with ``compare(_:)``.
   public typealias ComparatorBlock = (_ control: T, _ candidate: T) -> Bool
 
   /// Type of block which define the conditions to ignore comparing observations.
@@ -16,33 +30,90 @@ final public class Experiment<T: Equatable> {
     _ control: Observation<T>, _ candidate: Observation<T>
   ) -> Bool
 
+  /// Whether the candidates run.
+  ///
+  /// Defaults to `{ false }`, so an experiment stays dormant until you opt in. It is
+  /// evaluated on every ``run(name:)``, which is where a feature flag or a percentage
+  /// rollout belongs.
   public var enabled: () -> Bool = { return false }
+
+  /// Arbitrary values carried alongside the experiment.
+  ///
+  /// A publish handler reads them back from ``Result/experiment``, which is useful for
+  /// tagging published data with a request id, a user segment, and the like.
   public var context: [String: Any] = [:]
+
+  /// Called with the ``Result`` once every behavior has run.
+  ///
+  /// This is where the outcome is recorded — a metrics backend, a log, an error reporter.
+  /// It is not called when the experiment does not run; see ``enabled``.
   public var publish: ((Result<T>) -> Void)?
 
+  /// The name this experiment was created with.
   public private(set) var name: String
 
   private var behaviors: [String: ExperimentBlock] = [:]
   private var comparator: ComparatorBlock?
   private var ignoreConditions: [IgnoreObservationsBlock] = []
 
+  /// Registers the existing code path, under the name `"control"`.
+  ///
+  /// Its value is what ``run(name:)`` returns, and what the candidates are compared
+  /// against.
+  ///
+  /// - Parameter control: Block producing the current behavior.
   public func use(control: @escaping ExperimentBlock) {
     tryNew(name: Constants.defaultControlName, candidate: control)
   }
 
+  /// Registers a code path to compare against the control.
+  ///
+  /// Call it more than once to compare several candidates in the same experiment.
+  /// Registering two candidates under the same name keeps only the last one.
+  ///
+  /// - Parameters:
+  ///   - name: Identifies the candidate in the published ``Result``. Defaults to
+  ///     `"candidate"`.
+  ///   - candidate: Block producing the new behavior.
   public func tryNew(name: String? = nil, candidate: @escaping ExperimentBlock) {
     let blockName = name ?? Constants.defaultCandidateName
     behaviors[blockName] = candidate
   }
 
+  /// Registers a condition that suppresses mismatches it matches.
+  ///
+  /// Ignored mismatches are reported in ``Result/ignores`` instead of
+  /// ``Result/mismatches``, which keeps known-acceptable differences out of the mismatch
+  /// count without hiding them. Conditions accumulate: a mismatch is ignored when any of
+  /// them returns `true`.
+  ///
+  /// - Parameter condition: Returns `true` for a mismatch that should be ignored.
   public func ignores(_ condition: @escaping IgnoreObservationsBlock) {
     ignoreConditions.append(condition)
   }
 
+  /// Compares observations with `compare` instead of `==`.
+  ///
+  /// Use it when equality is not the right test — values that carry a timestamp, an
+  /// ordering that does not matter, a tolerance on a floating-point result.
+  ///
+  /// - Parameter compare: Returns `true` when the two values count as equivalent.
   public func compare(_ compare: @escaping ComparatorBlock) {
     comparator = compare
   }
 
+  /// Runs every registered behavior, publishes the result, and returns the control's
+  /// value.
+  ///
+  /// When ``enabled`` returns `false`, or fewer than two behaviors are registered, only
+  /// the named block runs: nothing is compared and ``publish`` is not called.
+  ///
+  /// - Parameter name: Which behavior to treat as the control, both for comparison and
+  ///   for the returned value. Defaults to `"control"`.
+  /// - Returns: The value returned by the named behavior.
+  /// - Throws: ``ExperimentError/behaviorNotFound`` if no behavior is registered under
+  ///   `name`, or ``ExperimentError/valueNotReturned`` if the run produced no observation
+  ///   for it.
   public func run(name: String? = nil) throws -> T {
     let executedBehavior: String = name ?? Constants.defaultControlName
 

--- a/Sources/Scientist/Observation.swift
+++ b/Sources/Scientist/Observation.swift
@@ -8,11 +8,24 @@
 
 import Foundation
 
+/// What a single behavior returned, and what it cost to get there.
+///
+/// One is created per registered behavior each time an experiment runs, and they reach a
+/// publish handler through ``Result``.
 public struct Observation<T: Equatable> {
+  /// When the block started running.
   public var now: Date
+
+  /// The experiment this observation belongs to.
   public var experiment: Experiment<T>
+
+  /// The name the behavior was registered under, `"control"` by default.
   public var name: String
+
+  /// The value the block returned.
   public var value: T
+
+  /// How long the block took, in milliseconds.
   public var during: Double
 
   init(name: String, experiment: Experiment<T>, block: Experiment<T>.ExperimentBlock) {

--- a/Sources/Scientist/Result.swift
+++ b/Sources/Scientist/Result.swift
@@ -8,33 +8,50 @@
 
 import Foundation
 
-/// `Result` is a container of the results of the experiment.
+/// What one run of an experiment produced.
+///
+/// It is built once per run and handed to ``Experiment/publish``, which is the only place
+/// the outcome is reported.
 public struct Result<T: Equatable> {
 
-  /// The experiment you conducted.
+  /// The experiment that produced this result.
+  ///
+  /// Its ``Experiment/name`` and ``Experiment/context`` identify what was measured.
   public let experiment: Experiment<T>
 
-  /// Control observation contains experiment for the existing logicA.
+  /// The observation the candidates were compared against, and whose value the run
+  /// returned.
+  ///
+  /// This is the behavior named `"control"` unless the `"run"` option named another one.
   public let control: Observation<T>?
 
-  /// All Observations
+  /// Every observation, the control included.
   public let observations: [Observation<T>]
 
-  /// The Observations except Control observation.
+  /// Every observation except the control.
   public let candidates: [Observation<T>]
 
-  /// The observation that contains
+  /// Candidates that did not match the control and were not ignored.
   public var mismatches: [Observation<T>] = []
+
+  /// Candidates that did not match the control but were suppressed by a condition
+  /// registered with ``Experiment/ignores(_:)``.
   public var ignores: [Observation<T>] = []
 
+  /// Whether any candidate mismatched the control without being ignored.
   public func mismatched() -> Bool {
     return mismatches.count > 0
   }
 
+  /// Whether any mismatch was ignored.
   public func ignored() -> Bool {
     return ignores.count > 0
   }
 
+  /// Whether every candidate matched the control.
+  ///
+  /// An ignored mismatch is not a match: a result with ignored candidates reports `false`
+  /// here and `false` from ``mismatched()`` alike.
   public func matched() -> Bool {
     return !mismatched() && !ignored()
   }

--- a/Sources/Scientist/Scientist.swift
+++ b/Sources/Scientist/Scientist.swift
@@ -6,27 +6,45 @@
 //  Copyright © 2018 Yusuke Ohashi. All rights reserved.
 //
 
-/// `Scientist` provides interface to run experiment.
-/// You have to specify return type which is `Equatable`.
+/// The entry point for running an experiment.
+///
+/// Each instance is generic over the single `Equatable` type its experiments return:
+///
+/// ```swift
+/// let allowed = try Scientist<Bool>().science { experiment in
+///   experiment.enabled = { true }
+///   experiment.publish = { result in metrics.record(result) }
+///   experiment.use { legacyCheck(user) }
+///   experiment.tryNew { user.allowed }
+/// }
+/// ```
 public struct Scientist<T: Equatable> {
   var defaultScientistContext: [String: Any]
 
+  /// Creates a scientist whose experiments start with an empty context.
   public init() {
     self.init(with: nil)
   }
 
+  /// Creates a scientist that seeds every experiment's ``Experiment/context`` with the
+  /// given values.
+  ///
+  /// - Parameter context: Values applied to each experiment before the configuration
+  ///   closure runs, so the closure can add to or replace them.
   public init(with context: [String: Any]? = nil) {
     defaultScientistContext = context ?? [:]
   }
 
-  /// conduct science.
+  /// Configures an experiment and runs it.
   ///
   /// - Parameters:
-  ///    - name: name of experiment
-  ///    - options: options for running experiment
-  ///    - process: your experiment process
-  ///
-  /// - Returns: Generic Type which conforms to Equatable
+  ///   - name: Identifies the experiment in the published ``Result``.
+  ///   - options: Run options. `"run"` names the behavior to treat as the control,
+  ///     both for comparison and for the returned value.
+  ///   - process: Closure that registers the behaviors on the ``Experiment``.
+  /// - Returns: The value returned by the control behavior.
+  /// - Throws: ``ExperimentError`` if the requested behavior is missing or produced no
+  ///   value.
   public func science(
     name: String = "", options: [String: Any] = [:], _ process: (Experiment<T>) -> Void
   ) throws -> T {
@@ -36,14 +54,18 @@ public struct Scientist<T: Equatable> {
     }
   }
 
-  /// run experiment excplicitly.
+  /// Configures an experiment and runs it, without a scientist instance.
+  ///
+  /// Same as ``science(name:options:_:)``, except that no default context is applied.
   ///
   /// - Parameters:
-  ///    - name: name of experiment
-  ///    - options: options for running experiment
-  ///    - process: your experiment process
-  ///
-  /// - Returns: Generic Type which conforms to Equatable
+  ///   - name: Identifies the experiment in the published ``Result``.
+  ///   - options: Run options. `"run"` names the behavior to treat as the control,
+  ///     both for comparison and for the returned value.
+  ///   - process: Closure that registers the behaviors on the ``Experiment``.
+  /// - Returns: The value returned by the control behavior.
+  /// - Throws: ``ExperimentError`` if the requested behavior is missing or produced no
+  ///   value.
   public static func run(
     name: String = "", options: [String: Any] = [:], _ process: (Experiment<T>) -> Void
   ) throws -> T {


### PR DESCRIPTION
Most of the public surface had no doc comments, so behavior that is only visible in the implementation was undocumented: what `enabled` defaults to, that `publish` is skipped when the experiment does not run, that an ignored mismatch is not a match, which errors `run(name:)` can throw.

Comments every public declaration and replaces the few existing comments that described the port rather than the behavior.

Verified with DocC (using the plugin from #17): the site builds with no unresolved symbol links. `swift test` and `swift format lint` pass.