### PR TITLE
Build and test on Linux in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -16,3 +16,14 @@ jobs:
       - run: swift build -v
       - run: swift test -v
       - run: swift format lint -r Sources Tests
+
+  linux:
+    runs-on: ubuntu-latest
+    # The package supports Linux, and the toolchain differs enough from Xcode's
+    # to be worth building separately. Linting runs on macOS only; it would
+    # report the same thing here.
+    container: swift:6.1
+    steps:
+      - uses: actions/checkout@v4
+      - run: swift build -v
+      - run: swift test -v


### PR DESCRIPTION
CI ran on macOS alone, so nothing verified the package on Linux even though it builds and is used there.

Adds a job on `ubuntu-latest` using the official `swift:6.1` image, running `swift build` and `swift test`. Linting stays on the macOS job, where it reports the same thing.

Verified locally in the same image via `./scripts/swift-container.sh`: build, test (9 passed) and lint all pass.