### PR TITLE
Point the coverage badge at main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Scientist
 
 [![CI](https://github.com/junkpiano/scientist/actions/workflows/ci.yml/badge.svg)](https://github.com/junkpiano/scientist/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/junkpiano/scientist/branch/master/graph/badge.svg)](https://codecov.io/gh/junkpiano/scientist)
+[![codecov](https://codecov.io/gh/junkpiano/scientist/branch/main/graph/badge.svg)](https://codecov.io/gh/junkpiano/scientist)
 
 A Swift library for carefully refactoring critical paths.
 


### PR DESCRIPTION
The default branch was renamed from `master`; the badge URL still asked codecov for a branch that no longer exists.

The workflow triggers are updated in #17 and #19, which already touch those files.