### PR TITLE
Point the installation example at 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Swift library for carefully refactoring critical paths.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/junkpiano/scientist.git", from: "0.4.0")
+    .package(url: "https://github.com/junkpiano/scientist.git", from: "0.6.0")
 ]
 ```
 


### PR DESCRIPTION
The installation example still asked for 0.4.0, two releases back. Updating ahead of tagging 0.6.0.