### PR TITLE
Document comparing implementations from different coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,48 @@ dependencies: [
 
 Full Documentation is available [Here](https://junkpiano.github.io/scientist/documentation/scientist).
 
+## Comparing implementations from different coding agents
+
+An experiment runs several implementations of the same thing against real traffic and
+reports whether they agreed, which makes it a way to compare code written by different
+coding agents. Register each agent's version as its own candidate and let production
+inputs decide:
+
+```swift
+let total = try Scientist<Int>().science(name: "checkout total") { experiment in
+  // Sample 5% of traffic.
+  experiment.enabled = { Int.random(in: 1...100) <= 5 }
+
+  experiment.use { currentTotal(cart) }                    // what ships today
+  experiment.tryNew(name: "agent-a") { agentATotal(cart) }
+  experiment.tryNew(name: "agent-b") { agentBTotal(cart) }
+
+  experiment.publish = { result in
+    for observation in result.observations {
+      metrics.record("\(result.experiment.name).\(observation.name).ms", observation.during)
+    }
+    for mismatch in result.mismatches {
+      metrics.increment("\(result.experiment.name).\(mismatch.name).mismatch")
+    }
+  }
+}
+```
+
+Every `Observation` carries both the value its block returned and `during`, how long it
+took in milliseconds, so a publish handler sees each half of the comparison: whether an
+agent's version agrees with the one in production, and what it cost to run. The control's
+value is what gets returned either way, so an agent's implementation cannot change the
+result while it is being evaluated.
+
+Two things worth knowing before reading anything into the numbers:
+
+- This is not a benchmark harness. Each behavior runs once per experiment, in-process and
+  in sequence, with no warmup, so a single `during` is mostly noise. The signal is in
+  aggregating many runs over the inputs the code actually sees.
+- A candidate that traps takes the process down with it. `ExperimentBlock` cannot throw,
+  so an implementation you do not trust yet needs to handle its own failures inside the
+  block.
+
 ## Development
 
 please run test before you send pull request


### PR DESCRIPTION
The library fits the question of which coding agent's implementation is actually correct and fast, judged against real traffic rather than a benchmark, but nothing in the README pointed that way.

Adds a section showing several agents' implementations registered as candidates, with a publish handler recording each observation's duration and each mismatch.

It also states the two limits that decide how much the numbers mean: each behavior runs once per experiment in sequence with no warmup, so a single `during` is noise; and a candidate that traps takes the process down, since `ExperimentBlock` cannot throw.

The example was type-checked against the module rather than written by eye.