### PR TITLE
Add the error-coverage tests missed by #27

### DIFF
--- a/Tests/ScientistTests/ScientistTests.swift
+++ b/Tests/ScientistTests/ScientistTests.swift
@@ -197,6 +197,16 @@ class ScientistTests: XCTestCase {
     case other
   }
 
+  // Two distinct types that describe themselves identically, to pin down that the default
+  // error comparison looks at the type and not only the description.
+  private struct DescribedError: Error, CustomStringConvertible {
+    let description: String
+  }
+
+  private struct OtherDescribedError: Error, CustomStringConvertible {
+    let description: String
+  }
+
   func testThrowingCandidateIsRecordedAndDoesNotReachTheCaller() throws {
     var result: Result<String>?
 
@@ -251,7 +261,9 @@ class ScientistTests: XCTestCase {
         experiment.use(control: { throw TestError.boom })
         experiment.tryNew(candidate: { throw TestError.boom })
       }
-    )
+    ) { error in
+      XCTAssertEqual(error as? TestError, .boom)
+    }
 
     let published = try XCTUnwrap(result, "publish should have been called.")
     XCTAssertEqual(published.mismatches.count, 0, "the same failure on both sides is a match.")
@@ -269,10 +281,108 @@ class ScientistTests: XCTestCase {
         experiment.use(control: { throw TestError.boom })
         experiment.tryNew(candidate: { throw TestError.other })
       }
-    )
+    ) { error in
+      XCTAssertEqual(error as? TestError, .boom, "the control's error, not the candidate's.")
+    }
 
     let published = try XCTUnwrap(result, "publish should have been called.")
     XCTAssertEqual(published.mismatches.map { $0.name }, ["candidate"])
+  }
+
+  func testRunOptionSelectsWhichErrorPropagates() {
+    XCTAssertThrowsError(
+      try Scientist<String>().science(options: [Constants.runParameter: "candidate"]) {
+        experiment in
+        experiment.enabled = { true }
+
+        experiment.use(control: { throw TestError.boom })
+        experiment.tryNew(candidate: { throw TestError.other })
+      }
+    ) { error in
+      XCTAssertEqual(error as? TestError, .other, "the named behavior's error is the caller's.")
+    }
+  }
+
+  func testDefaultErrorComparisonDistinguishesTypesWithTheSameDescription() throws {
+    var result: Result<String>?
+
+    XCTAssertThrowsError(
+      try Scientist<String>().science { experiment in
+        experiment.enabled = { true }
+        experiment.publish = { result = $0 }
+
+        experiment.use(control: { throw DescribedError(description: "boom") })
+        experiment.tryNew(candidate: { throw OtherDescribedError(description: "boom") })
+      }
+    )
+
+    let published = try XCTUnwrap(result, "publish should have been called.")
+    XCTAssertEqual(
+      published.mismatches.map { $0.name }, ["candidate"],
+      "errors of different types are not equivalent, however they describe themselves.")
+  }
+
+  func testCompareErrorsCanRejectIdenticalErrors() throws {
+    var result: Result<String>?
+
+    XCTAssertThrowsError(
+      try Scientist<String>().science { experiment in
+        experiment.enabled = { true }
+        experiment.publish = { result = $0 }
+
+        experiment.use(control: { throw TestError.boom })
+        experiment.tryNew(candidate: { throw TestError.boom })
+
+        // The same error on both sides, rejected by the block.
+        experiment.compareErrors { _, _ in false }
+      }
+    )
+
+    let published = try XCTUnwrap(result, "publish should have been called.")
+    XCTAssertEqual(
+      published.mismatches.map { $0.name }, ["candidate"],
+      "the registered block decides, not the default comparison.")
+  }
+
+  func testComparatorsReceiveTheControlThenTheCandidate() throws {
+    var seenControlValue: String?
+    var seenCandidateValue: String?
+    var seenControlError: TestError?
+    var seenCandidateError: TestError?
+
+    _ = try Scientist<String>().science { experiment in
+      experiment.enabled = { true }
+
+      experiment.use(control: { "control value" })
+      experiment.tryNew(candidate: { "candidate value" })
+
+      experiment.compare { control, candidate in
+        seenControlValue = control
+        seenCandidateValue = candidate
+        return true
+      }
+    }
+
+    XCTAssertEqual(seenControlValue, "control value")
+    XCTAssertEqual(seenCandidateValue, "candidate value")
+
+    XCTAssertThrowsError(
+      try Scientist<String>().science { experiment in
+        experiment.enabled = { true }
+
+        experiment.use(control: { throw TestError.boom })
+        experiment.tryNew(candidate: { throw TestError.other })
+
+        experiment.compareErrors { control, candidate in
+          seenControlError = control as? TestError
+          seenCandidateError = candidate as? TestError
+          return true
+        }
+      }
+    )
+
+    XCTAssertEqual(seenControlError, .boom)
+    XCTAssertEqual(seenCandidateError, .other)
   }
 
   func testThrowingIsNeverEquivalentToReturning() throws {


### PR DESCRIPTION
Four tests written against the codex review of #27 never made it into that PR. The branch was squashed with `git reset --soft` before the final push, which commits the index, and the edits made after the last `git add` were unstaged. #27 merged with 16 tests instead of 20, so the review comment on it claiming these were addressed does not match what landed.

The implementation itself is unaffected — this is test coverage only.

What they pin down:

- Errors of different types that describe themselves identically still mismatch, so the default comparison cannot quietly drop its `type(of:)` check.
- A `compareErrors` block that rejects identical errors is honored, so an implementation cannot match merely because a block was registered.
- Both comparators receive the control first and the candidate second.
- The exact error that propagates is asserted, including under `options: ["run": "candidate"]`, where the candidate is the control for that run and its error is the caller's.

Checked by mutation against this branch: dropping the type check fails one test, swapping the comparator's arguments fails two, and rethrowing the first failing observation instead of the control's fails three. Without these four tests all three mutants pass.