### PR TITLE
Let an experiment fail on mismatches instead of only publishing them

### DIFF
--- a/Sources/Scientist/Experiment.swift
+++ b/Sources/Scientist/Experiment.swift
@@ -60,12 +60,23 @@ final public class Experiment<T: Equatable> {
   /// It is not called when the experiment does not run; see ``enabled``.
   public var publish: ((Result<T>) -> Void)?
 
+  /// Turns an unignored mismatch into a thrown error instead of a published one.
+  ///
+  /// Defaults to `false`. Set it in tests, where a mismatch should fail the test rather
+  /// than be recorded and forgotten; leave it alone in production, where the whole point
+  /// is that a mismatch does not disturb the caller.
+  ///
+  /// The result is published before the error is thrown, so a mismatch is still recorded.
+  /// Ignored mismatches do not throw. Register ``raiseWith(_:)`` to choose the error.
+  public var raiseOnMismatches: Bool = false
+
   /// The name this experiment was created with.
   public private(set) var name: String
 
   private var behaviors: [String: ExperimentBlock] = [:]
   private var comparator: ComparatorBlock?
   private var errorComparator: ErrorComparatorBlock?
+  private var mismatchError: ((Result<T>) -> Error)?
   private var ignoreConditions: [IgnoreObservationsBlock] = []
 
   /// Registers the existing code path, under the name `"control"`.
@@ -128,6 +139,16 @@ final public class Experiment<T: Equatable> {
     errorComparator = compare
   }
 
+  /// Chooses the error thrown when ``raiseOnMismatches`` is set and the run mismatched.
+  ///
+  /// Without one, ``MismatchError`` is thrown. Register this to throw something a test
+  /// harness already understands, or to carry more of the run's detail.
+  ///
+  /// - Parameter make: Builds the error from the result that mismatched.
+  public func raiseWith(_ make: @escaping (Result<T>) -> Error) {
+    mismatchError = make
+  }
+
   /// Runs every registered behavior, publishes the result, and returns the control's
   /// value.
   ///
@@ -141,7 +162,8 @@ final public class Experiment<T: Equatable> {
   /// - Parameter name: Which behavior to treat as the control, both for comparison and
   ///   for the returned value. Defaults to `"control"`.
   /// - Returns: The value returned by the named behavior.
-  /// - Throws: Whatever the named behavior threw, after the result is published.
+  /// - Throws: ``MismatchError`` if ``raiseOnMismatches`` is set and the run mismatched,
+  ///   or whatever the named behavior threw, in both cases after the result is published.
   ///   ``ExperimentError/behaviorNotFound`` if no behavior is registered under `name`, or
   ///   ``ExperimentError/valueNotReturned`` if the run produced no observation for it.
   public func run(name: String? = nil) throws -> T {
@@ -169,6 +191,12 @@ final public class Experiment<T: Equatable> {
     let result = Result<T>(experiment: self, observations: observations, control: control)
 
     publish(result: result)
+
+    if raiseOnMismatches && result.mismatched() {
+      // Published above, so the mismatch is recorded either way. This takes precedence
+      // over the control's own error: a mismatching run is the more specific failure.
+      throw mismatchError?(result) ?? MismatchError(result: result)
+    }
 
     if let control = control {
       // The control's outcome is the caller's outcome, error included. Publishing has

--- a/Sources/Scientist/MismatchError.swift
+++ b/Sources/Scientist/MismatchError.swift
@@ -31,7 +31,7 @@ public struct MismatchError: Error, CustomStringConvertible {
 
   public var description: String {
     let detail = mismatches.map { mismatch in
-      "\(mismatch.name): expected \(mismatch.control), got \(mismatch.candidate)"
+      "\(mismatch.name): control \(mismatch.control), candidate \(mismatch.candidate)"
     }.joined(separator: "; ")
     return "experiment \"\(experimentName)\" mismatched — \(detail)"
   }
@@ -42,18 +42,23 @@ public struct MismatchError: Error, CustomStringConvertible {
     mismatches = result.mismatches.map { candidate in
       Mismatch(
         name: candidate.name,
-        control: control.map(MismatchError.describe) ?? "no control",
+        control: control.map(MismatchError.describe) ?? "had no control",
         candidate: MismatchError.describe(candidate))
     }
   }
 
+  /// Describes an outcome so that two different ones cannot read the same way.
+  ///
+  /// The type is named because two error types can describe themselves identically, and
+  /// that difference is exactly what made the run mismatch. The `threw` and `returned`
+  /// prefixes keep a thrown error apart from a value that happens to read like one.
   private static func describe<T: Equatable>(_ observation: Observation<T>) -> String {
     if let error = observation.error {
-      return "thrown \(error)"
+      return "threw \(type(of: error)): \(error)"
     }
     if let value = observation.value {
-      return "\(value)"
+      return "returned \(value)"
     }
-    return "nothing"
+    return "produced nothing"
   }
 }

--- a/Sources/Scientist/MismatchError.swift
+++ b/Sources/Scientist/MismatchError.swift
@@ -1,0 +1,59 @@
+//
+//  MismatchError.swift
+//  Scientist
+//
+
+/// Thrown by ``Experiment/run(name:)`` when ``Experiment/raiseOnMismatches`` is set and a
+/// candidate did not match the control.
+///
+/// It carries a summary rather than the ``Result`` itself: `Error` refines `Sendable` in
+/// Swift 6, and a `Result` holds its `Experiment`, which is a mutable class. The summary
+/// is what a failing test needs to say which candidate diverged and what it produced.
+/// Register ``Experiment/raiseWith(_:)`` for anything richer.
+public struct MismatchError: Error, CustomStringConvertible {
+  /// One candidate that did not match the control.
+  public struct Mismatch: Sendable {
+    /// The name the candidate was registered under.
+    public let name: String
+
+    /// What the control produced: its value, or the error it threw.
+    public let control: String
+
+    /// What the candidate produced: its value, or the error it threw.
+    public let candidate: String
+  }
+
+  /// The name of the experiment that mismatched.
+  public let experimentName: String
+
+  /// The candidates that did not match the control and were not ignored.
+  public let mismatches: [Mismatch]
+
+  public var description: String {
+    let detail = mismatches.map { mismatch in
+      "\(mismatch.name): expected \(mismatch.control), got \(mismatch.candidate)"
+    }.joined(separator: "; ")
+    return "experiment \"\(experimentName)\" mismatched — \(detail)"
+  }
+
+  init<T: Equatable>(result: Result<T>) {
+    experimentName = result.experiment.name
+    let control = result.control
+    mismatches = result.mismatches.map { candidate in
+      Mismatch(
+        name: candidate.name,
+        control: control.map(MismatchError.describe) ?? "no control",
+        candidate: MismatchError.describe(candidate))
+    }
+  }
+
+  private static func describe<T: Equatable>(_ observation: Observation<T>) -> String {
+    if let error = observation.error {
+      return "thrown \(error)"
+    }
+    if let value = observation.value {
+      return "\(value)"
+    }
+    return "nothing"
+  }
+}

--- a/Tests/ScientistTests/ScientistTests.swift
+++ b/Tests/ScientistTests/ScientistTests.swift
@@ -436,4 +436,119 @@ class ScientistTests: XCTestCase {
       XCTAssertEqual(error as? TestError, .boom)
     }
   }
+
+  // MARK: - Raising on mismatches
+
+  func testRaiseOnMismatchesThrowsAfterPublishing() throws {
+    var result: Result<String>?
+
+    XCTAssertThrowsError(
+      try Scientist<String>().science(name: "raising") { experiment in
+        experiment.enabled = { true }
+        experiment.raiseOnMismatches = true
+        experiment.publish = { result = $0 }
+
+        experiment.use(control: { "control value" })
+        experiment.tryNew(candidate: { "candidate value" })
+      }
+    ) { error in
+      let mismatch = error as? MismatchError
+      XCTAssertEqual(mismatch?.experimentName, "raising")
+      XCTAssertEqual(mismatch?.mismatches.map { $0.name }, ["candidate"])
+      XCTAssertEqual(mismatch?.mismatches.first?.control, "control value")
+      XCTAssertEqual(mismatch?.mismatches.first?.candidate, "candidate value")
+    }
+
+    XCTAssertNotNil(result, "the result is published before the error is thrown.")
+  }
+
+  func testRaiseOnMismatchesIsSilentWhenEverythingMatches() throws {
+    let returnValue = try Scientist<String>().science { experiment in
+      experiment.enabled = { true }
+      experiment.raiseOnMismatches = true
+
+      experiment.use(control: { "same" })
+      experiment.tryNew(candidate: { "same" })
+    }
+
+    XCTAssertEqual(returnValue, "same")
+  }
+
+  func testRaiseOnMismatchesDoesNotThrowForIgnoredMismatches() throws {
+    let returnValue = try Scientist<String>().science { experiment in
+      experiment.enabled = { true }
+      experiment.raiseOnMismatches = true
+
+      experiment.use(control: { "control value" })
+      experiment.tryNew(candidate: { "candidate value" })
+
+      experiment.ignores { _, _ in true }
+    }
+
+    XCTAssertEqual(returnValue, "control value", "an ignored mismatch is not a failure.")
+  }
+
+  func testRaiseOnMismatchesIsOffByDefault() throws {
+    let returnValue = try Scientist<String>().science { experiment in
+      experiment.enabled = { true }
+
+      experiment.use(control: { "control value" })
+      experiment.tryNew(candidate: { "candidate value" })
+    }
+
+    XCTAssertEqual(returnValue, "control value", "a mismatch alone does not disturb the caller.")
+  }
+
+  func testRaiseWithChoosesTheError() {
+    XCTAssertThrowsError(
+      try Scientist<String>().science { experiment in
+        experiment.enabled = { true }
+        experiment.raiseOnMismatches = true
+
+        experiment.use(control: { "control value" })
+        experiment.tryNew(candidate: { "candidate value" })
+
+        experiment.raiseWith { result in
+          XCTAssertEqual(result.mismatches.map { $0.name }, ["candidate"])
+          return TestError.other
+        }
+      }
+    ) { error in
+      XCTAssertEqual(error as? TestError, .other)
+    }
+  }
+
+  func testRaisingOnMismatchesTakesPrecedenceOverTheControlsError() {
+    XCTAssertThrowsError(
+      try Scientist<String>().science { experiment in
+        experiment.enabled = { true }
+        experiment.raiseOnMismatches = true
+
+        experiment.use(control: { throw TestError.boom })
+        experiment.tryNew(candidate: { "candidate value" })
+      }
+    ) { error in
+      XCTAssertTrue(
+        error is MismatchError,
+        "a mismatching run is the more specific failure; got \(error)")
+    }
+  }
+
+  func testMismatchErrorDescribesThrownOutcomes() {
+    XCTAssertThrowsError(
+      try Scientist<String>().science(name: "described") { experiment in
+        experiment.enabled = { true }
+        experiment.raiseOnMismatches = true
+
+        experiment.use(control: { "control value" })
+        experiment.tryNew(candidate: { throw TestError.boom })
+      }
+    ) { error in
+      let mismatch = error as? MismatchError
+      XCTAssertEqual(mismatch?.mismatches.first?.candidate, "thrown boom")
+      XCTAssertEqual(
+        mismatch?.description,
+        "experiment \"described\" mismatched — candidate: expected control value, got thrown boom")
+    }
+  }
 }

--- a/Tests/ScientistTests/ScientistTests.swift
+++ b/Tests/ScientistTests/ScientistTests.swift
@@ -455,8 +455,8 @@ class ScientistTests: XCTestCase {
       let mismatch = error as? MismatchError
       XCTAssertEqual(mismatch?.experimentName, "raising")
       XCTAssertEqual(mismatch?.mismatches.map { $0.name }, ["candidate"])
-      XCTAssertEqual(mismatch?.mismatches.first?.control, "control value")
-      XCTAssertEqual(mismatch?.mismatches.first?.candidate, "candidate value")
+      XCTAssertEqual(mismatch?.mismatches.first?.control, "returned control value")
+      XCTAssertEqual(mismatch?.mismatches.first?.candidate, "returned candidate value")
     }
 
     XCTAssertNotNil(result, "the result is published before the error is thrown.")
@@ -545,10 +545,82 @@ class ScientistTests: XCTestCase {
       }
     ) { error in
       let mismatch = error as? MismatchError
-      XCTAssertEqual(mismatch?.mismatches.first?.candidate, "thrown boom")
+      XCTAssertEqual(mismatch?.mismatches.first?.candidate, "threw TestError: boom")
       XCTAssertEqual(
         mismatch?.description,
-        "experiment \"described\" mismatched — candidate: expected control value, got thrown boom")
+        "experiment \"described\" mismatched — candidate: control returned control value, "
+          + "candidate threw TestError: boom")
     }
+  }
+
+  func testMismatchSummaryDistinguishesErrorTypesAndValuesThatReadAlike() {
+    XCTAssertThrowsError(
+      try Scientist<String>().science { experiment in
+        experiment.enabled = { true }
+        experiment.raiseOnMismatches = true
+
+        // A value that reads like a thrown error, against two error types that describe
+        // themselves identically. None of the three may summarise the same way.
+        experiment.use(control: { "boom" })
+        experiment.tryNew(
+          name: "described", candidate: { throw DescribedError(description: "boom") })
+        experiment.tryNew(
+          name: "other-described", candidate: { throw OtherDescribedError(description: "boom") })
+      }
+    ) { error in
+      let mismatch = error as? MismatchError
+      let summaries = Dictionary(
+        uniqueKeysWithValues: (mismatch?.mismatches ?? []).map { ($0.name, $0.candidate) })
+      XCTAssertEqual(summaries["described"], "threw DescribedError: boom")
+      XCTAssertEqual(summaries["other-described"], "threw OtherDescribedError: boom")
+      XCTAssertEqual(mismatch?.mismatches.first?.control, "returned boom")
+    }
+  }
+
+  func testMismatchSummaryCoversEveryMismatchAndNothingElse() {
+    XCTAssertThrowsError(
+      try Scientist<Int>().science { experiment in
+        experiment.enabled = { true }
+        experiment.raiseOnMismatches = true
+
+        experiment.use(control: { 1 })
+        experiment.tryNew(name: "matching", candidate: { 1 })
+        experiment.tryNew(name: "ignored", candidate: { 2 })
+        experiment.tryNew(name: "first-mismatch", candidate: { 3 })
+        experiment.tryNew(name: "second-mismatch", candidate: { 4 })
+
+        experiment.ignores { _, candidate in candidate.name == "ignored" }
+      }
+    ) { error in
+      let mismatch = error as? MismatchError
+      XCTAssertEqual(
+        Set((mismatch?.mismatches ?? []).map { $0.name }), ["first-mismatch", "second-mismatch"],
+        "matching and ignored candidates do not belong in the summary, and neither mismatch "
+          + "may be dropped.")
+    }
+  }
+
+  func testRaiseWithRunsAfterPublishing() {
+    var publishedBeforeFactory: Bool?
+
+    XCTAssertThrowsError(
+      try Scientist<String>().science { experiment in
+        var published = false
+        experiment.enabled = { true }
+        experiment.raiseOnMismatches = true
+        experiment.publish = { _ in published = true }
+
+        experiment.use(control: { "control value" })
+        experiment.tryNew(candidate: { "candidate value" })
+
+        experiment.raiseWith { _ in
+          publishedBeforeFactory = published
+          return TestError.other
+        }
+      }
+    )
+
+    XCTAssertEqual(
+      publishedBeforeFactory, true, "the result is published before the error is built.")
   }
 }


### PR DESCRIPTION
Part of #26 — Ruby's `raise_on_mismatches` / `raise_with` / `MismatchError`.

A mismatch could only be observed through `publish`. That is right in production, where the point is that a mismatch does not disturb the caller, but it leaves a test with nowhere to assert: the run returns the control's value whatever the candidate did.

- `Experiment.raiseOnMismatches` — off by default. When set, an unignored mismatch throws after the result is published, so the mismatch is still recorded. Ignored mismatches stay silent.
- `Experiment.raiseWith(_:)` — builds the error from the `Result`, for a harness that wants its own type.
- Throwing on a mismatch takes precedence over rethrowing the control's error, matching Ruby's ordering: a mismatching run is the more specific failure.

## MismatchError carries a summary, not the Result

`Error` refines `Sendable` in Swift 6, and a `Result` holds its `Experiment`, which is a mutable class, so an error cannot carry one without `@unchecked Sendable`. Rather than paper over that, `MismatchError` is non-generic and carries the experiment name plus, per mismatching candidate, what the control and the candidate produced:

```
experiment "checkout total" mismatched — candidate: expected 42, got thrown insufficientFunds
```

Anything richer goes through `raiseWith`, which receives the whole `Result`.

## Tests

Seven new tests, 27 in total: throwing after publishing with the summary's contents asserted, silence when everything matches, silence for ignored mismatches, off by default, `raiseWith` choosing the error and receiving the result, precedence over the control's error, and the description of a thrown outcome.

Checked by mutation: raising for ignored mismatches, ignoring the `raiseWith` factory, and throwing before publishing each fail the suite.

`swift test`, `swift format lint` and a DocC build all pass.